### PR TITLE
Fixing Invalid Transition error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea
 
 # rspec failure tracking
 .rspec_status

--- a/argon.gemspec
+++ b/argon.gemspec
@@ -1,31 +1,31 @@
 # coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "argon/version"
+require 'argon/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "argon"
-  spec.version       = Argon::VERSION
-  spec.authors       = ["Ajith Hussain"]
-  spec.email         = ["csy0013@googlemail.com"]
+  spec.name = 'argon'
+  spec.version = Argon::VERSION
+  spec.authors = ['Ajith Hussain', 'Louis Sayers']
+  spec.email = %w(csy0013@googlemail.com louis@tribegroup.co)
 
-  spec.summary       = %q{Argon generates a workflow engine (built around a state machine)}
-  spec.homepage      = "https://github.com/sparkymat/argon"
-  spec.license       = "MIT"
+  spec.summary = 'Argon generates a workflow engine (built around a state machine)'
+  spec.homepage = 'https://github.com/sparkymat/argon'
+  spec.license = 'MIT'
 
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rails"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "symbolic_enum", '~> 1.1', '>= 1.1.4'
+  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'symbolic_enum', '~> 1.1', '>= 1.1.4'
 end

--- a/lib/argon.rb
+++ b/lib/argon.rb
@@ -159,17 +159,20 @@ module Argon
             end
           end
 
-          if self.send(field) != from
-            if on_failed_transition
-              self.on_failed_transition(field: field, action: action, from: from, to: to)
-            end
-            raise Argon::InvalidTransitionError.new("Invalid state transition. #{ self.class.name }##{ self.send(self.class.primary_key.to_sym) } cannot perform '#{action}' on #{field}='#{from}'")
-          end
-
+          before_lock_state = self.send(field)
           begin
             self.with_lock do
-              if self.send(field) != from
-                raise Argon::InvalidTransitionError.new("Invalid state transition. #{ self.class.name }##{ self.send(self.class.primary_key.to_sym) } cannot perform '#{action}' on #{field}='#{from}'")
+              current_state = self.send(field)
+
+              if before_lock_state != current_state
+                error_msg = "State of #{ class_name }##{ identifier } changed from #{before_lock_state} to #{current_state} while waiting for a lock"
+                raise Argon::ConcurrentProcessingError.new(error_msg)
+              end
+
+              if current_state != from
+                class_name = self.class.name
+                identifier = self.send(self.class.primary_key.to_sym)
+                raise Argon::InvalidTransitionError.new("Invalid state transition. #{ class_name }##{ identifier } cannot perform '#{action}' on #{field}='#{current_state}'")
               end
 
               self.update_column(field, self.class.send("#{ field.to_s.pluralize }").map{|v| [v[0],v[1]]}.to_h[to])
@@ -183,9 +186,7 @@ module Argon
                 end
               end
 
-              unless block.nil?
-                block.call
-              end
+              block.call unless block.nil?
             end
           rescue => e
             if on_failed_transition

--- a/lib/argon/concurrent_processing_error.rb
+++ b/lib/argon/concurrent_processing_error.rb
@@ -1,0 +1,2 @@
+class Argon::ConcurrentProcessingError < StandardError
+end

--- a/lib/argon/version.rb
+++ b/lib/argon/version.rb
@@ -1,3 +1,3 @@
 module Argon
-  VERSION = "1.3.0"
+  VERSION = '1.3.1'
 end

--- a/spec/argon_spec.rb
+++ b/spec/argon_spec.rb
@@ -1144,7 +1144,7 @@ RSpec.describe Argon do
       instance.update_column(:state, 2)
       expect(instance.state).to eq :def
 
-      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='abc'")
+      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='def'")
     end
   end
 
@@ -1215,7 +1215,7 @@ RSpec.describe Argon do
       instance.update_column(:state, 2)
       expect(instance.state).to eq :def
 
-      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='abc'")
+      expect { instance.move! }.to raise_error(Argon::InvalidTransitionError, "Invalid state transition. SampleClass#1 cannot perform 'move' on state='def'")
     end
   end
 


### PR DESCRIPTION
Only raising Invalid State Transition error once, to ensure simultaneous state transitions won't interfere with one another, and fixed error message to show the current state that's being transitioned away from.